### PR TITLE
use TLSv1.2-only for SUPL

### DIFF
--- a/gps.xml.l10
+++ b/gps.xml.l10
@@ -18,7 +18,7 @@
        SuplLogFullName="/data/vendor/gps/suplflow.txt"
        tlsEnable="true"
 
-       SuplSslMethod="SSLv23_NO_TLSv1_2"
+       SuplSslMethod="TLSv1_2"
        SuplEnable="true"
        SuplUseApn="true"
        SuplTlsCertDirPath="/etc/security/cacerts"

--- a/gps_user.xml.l10
+++ b/gps_user.xml.l10
@@ -17,7 +17,7 @@
        SuplLogFullName="/data/vendor/gps/suplflow.txt"
        tlsEnable="true"
 
-       SuplSslMethod="SSLv23_NO_TLSv1_2"
+       SuplSslMethod="TLSv1_2"
        SuplEnable="true"
        SuplUseApn="true"
        SuplTlsCertDirPath="/etc/security/cacerts"


### PR DESCRIPTION
TLSv1.2 was previously disabled with SSLv2, SSLv3, TLSv1 and TLSv1.1 as the only supported protocol versions.