### PR TITLE
add support for enabling alternative touchscreen mode

### DIFF
--- a/conf/init.tangorpro.rc
+++ b/conf/init.tangorpro.rc
@@ -71,6 +71,9 @@ on property:vendor.all.modules.ready=1 && property:ro.build.flavor=factory_tango
     write /sys/devices/virtual/goog_touch_interface/gti.0/offload_enabled 0
     setprop persist.sys.tap_gesture 0
 
+on property:persist.sys.alt_touch_mode=1 && property:sys.state_of_default_display=on
+    write /sys/devices/platform/10d10000.spi/spi_master/spi0/spi0.0/input/nvt_touch/nvt_freq_hopping 1
+
 # Start the twoshay touch service
 on property:vendor.device.modules.ready=1
     start twoshay

--- a/tangorpro/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/tangorpro/overlay/frameworks/base/core/res/res/values/config.xml
@@ -720,4 +720,6 @@
     <bool name="config_showMenuShortcutsWhenKeyboardPresent">true</bool>
 
     <bool name="config_usb_port_security_applies_to_pogo_pins">true</bool>
+
+    <bool name="config_has_alternative_touchscreen_mode">true</bool>
 </resources>


### PR DESCRIPTION
The touchscreen is less susceptible to ghost touches when nvt_freq_hopping is set to MODE_1.

sys.state_of_default_display property reflects the state of default display. nvt_freq_hopping value has to be updated each time the display turns on.

See google-modules/touch/novatek/nt36xxx/nt36xxx_ext_api.c in kernel source for more info.

Depends on:
https://github.com/GrapheneOS/platform_system_sepolicy/pull/58
https://github.com/GrapheneOS/platform_frameworks_base/pull/544
https://github.com/GrapheneOS/platform_packages_apps_Settings/pull/254